### PR TITLE
Support FLATTEN transforms to extract payload of value.

### DIFF
--- a/cdcsdk-server/cdcsdk-server-null/src/main/java/org/yb/cdcsdk/server/nullstream/NullStreamChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-null/src/main/java/org/yb/cdcsdk/server/nullstream/NullStreamChangeConsumer.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.yb.cdcsdk.server.nullStream;
+package org.yb.cdcsdk.server.nullstream;
 
 import java.util.List;
 
@@ -13,8 +13,6 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +34,6 @@ public class NullStreamChangeConsumer extends BaseChangeConsumer
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NullStreamChangeConsumer.class);
 
-    private static final String PROP_PREFIX = "debezium.sink.null.";
-
     private long numLogged = 0;
     private long totalRecords = 0;
 
@@ -46,7 +42,6 @@ public class NullStreamChangeConsumer extends BaseChangeConsumer
 
     @PostConstruct
     void connect() {
-        final Config config = ConfigProvider.getConfig();
         LOGGER.info("Instaintiated NULL consumer");
     }
 

--- a/cdcsdk-server/cdcsdk-server-s3/src/main/java/com/yugabyte/cdcsdk/sink/s3/S3Storage.java
+++ b/cdcsdk-server/cdcsdk-server-s3/src/main/java/com/yugabyte/cdcsdk/sink/s3/S3Storage.java
@@ -206,12 +206,7 @@ public class S3Storage {
     }
 
     public void delete(String name) {
-        if (bucketName.equals(name)) {
-            // TODO: decide whether to support delete for the top-level bucket.
-            // s3.deleteBucket(name);
-            return;
-        }
-        else {
+        if (!bucketName.equals(name)) {
             s3.deleteObject(bucketName, name);
         }
     }

--- a/cdcsdk-server/cdcsdk-server-s3/src/test/java/com/yugabyte/cdcsdk/sink/s3/S3ConsumerIT.java
+++ b/cdcsdk-server/cdcsdk-server-s3/src/test/java/com/yugabyte/cdcsdk/sink/s3/S3ConsumerIT.java
@@ -175,8 +175,7 @@ public class S3ConsumerIT {
         for (String line : allLines) {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode node = mapper.readTree(line);
-            JsonNode after = node.get("payload").get("after");
-            assertEquals(mapper.readTree(expected.next()), after);
+            assertEquals(mapper.readTree(expected.next()), node);
         }
     }
 }

--- a/cdcsdk-server/cdcsdk-server-s3/src/test/java/com/yugabyte/cdcsdk/sink/s3/S3TestConfigSource.java
+++ b/cdcsdk-server/cdcsdk-server-s3/src/test/java/com/yugabyte/cdcsdk/sink/s3/S3TestConfigSource.java
@@ -18,7 +18,7 @@ public class S3TestConfigSource extends TestConfigSource {
         s3Test.put("cdcsdk.sink.s3.basedir", "S3ConsumerIT/");
         s3Test.put("cdcsdk.sink.s3.pattern", "stream_{EPOCH}");
         s3Test.put("cdcsdk.sink.s3.flushRecords", "4");
-        s3Test.put("cdcsdk.format.value", "json"); // Need to explicitly pass in the cloudevents format
+        s3Test.put("cdcsdk.server.transforms", "FLATTEN");
 
         s3Test.put("cdcsdk.source.connector.class", "io.debezium.connector.postgresql.PostgresConnector");
         s3Test.put("cdcsdk.source." + StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,


### PR DESCRIPTION
By default the server emits a complex record with schema and payload
containing before and after value. In many cases, the sinks requires a
simple record with the final values of the payload.

The server supports FLATTEN transform to generate the simple record
structure.