### PR TITLE
Create metrics infra using Micrometer. Export to Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ cdcsdk.source.database.master.addresses=127.0.0.1:7100
 cdcsdk.source.snapshot.mode=never
 ```
 
-For detailed documentation of the configuration, check [debezium docs](https://debezium.io/documentation/reference/stable/operations/debezium-server.html#_sink_configuration)
-
 ### Configuration using Environment Variables
 
 Configuration using environment variables maybe useful when running in containers. The rule of thumb
@@ -136,6 +134,14 @@ Additional configuration:
 |quarkus.log.level|INFO|The default log level for every log category.|
 |quarkus.log.console.json|true|Determine whether to enable the JSON console formatting extension, which disables "normal" console formatting.|
 
+### Kafka Client/Confluent Cloud
+The Kafka Client will stream changes to a Kafka Message Broker or to Confluent Cloud.
+
+|Property|Default|Description|
+|--------|-------|-----------|
+|cdcsdk.sink.type||Must be set to `kafka`|
+|cdcsdk.sink.kafka.producer.*||The Kafka sink adapter supports pass-through configuration. This means that all Kafka producer configuration properties are passed to the producer with the prefix removed.At least `bootstrap.servers`, `key.serializer` and `value.serializer` properties must be provided. At least `bootstrap.servers`, `key.serializer` and `value.serializer` properties must be provided. The topic is set by CDCSDK Server.|
+
 ### HTTP Client
 The HTTP Client will stream changes to any HTTP Server for additional processing.
 |Property|Default|Description|
@@ -146,7 +152,12 @@ The HTTP Client will stream changes to any HTTP Server for additional processing
 
 ### Amazon S3
 
-The Amazon S3 Sink streams changes to an AWS S3 bucket. Only **Inserts** are supported. The available configuration options are:
+The Amazon S3 Sink streams changes to an AWS S3 bucket. Only **Inserts** are supported.
+
+> **Note**
+> Amazon S3 Sink supports a single table at a time. Specifically cdcsdk.source.table.include.list should contain only one table at a time. If multiple tables need to be exported to Amazon S3, multiple CDCSDK servers that read from the same CDC Stream ID but write to different S3 locations should be setup.
+
+The available configuration options are:
 
 |Property|Default|Description|
 |--------|-------|-----------|

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ It supports a YugabyteDb instance as a source and supports the following sinks:
     - [Networking](#networking)
     - [Healthchecks](#healthchecks)
       - [Running the health check](#running-the-health-check)
+    - [Metrics](#metrics)
+      - [System Metrics](#system-metrics)
+      - [Application Metrics](#application-metrics)
+      - [Integration with Prometheus](#integration-with-prometheus)
 
 ## Basic architecture
 
@@ -304,8 +308,6 @@ status — the overall result of all the health check procedures
 checks — an array of individual checks
 
 The general status of the health check is computed as a logical AND of all the declared health check procedures.
-The checks array is currently empty as we have not specified any health check procedure yet.
-
 
 Example output:
 
@@ -329,4 +331,45 @@ curl http://localhost:8080/q/health/ready
     "checks": [
     ]
 }
+```
+
+### Metrics
+
+CDCSDK Server exposes metrics through a REST ENDPOINT: `q/metrics`. To view metrics, execute
+
+    curl localhost:8080/q/metrics/
+
+Refer to [Quarkus-Micrometer docs](https://quarkus.io/guides/micrometer#configuration-reference) for configuration options.
+
+#### System Metrics
+
+There are a number of system metrics to monitor JVM performance such as
+
+* jvm_gc_*
+* jvm_memory_*
+* jvm_threads_*
+
+#### Application Metrics
+
+Application metrics have the prefix `cdcsdk_`. The following metrics for the application are available.
+
+
+|Metric|Description|
+|------|-----------|
+|cdcsdk_server_health|A status code for the health of the server. 0: Healthy, 1: Not Healthy. In the future, more states will be available for different causes|
+|cdcsdk_sink_totalBytesWritten|No. of bytes written by the sink since the start of the application|
+|cdcsdk_sink_totalRecordsWritten|No. of records written by the sink since the start of the application|
+
+#### Integration with Prometheus
+
+Prometheus uses a pull model to get metrics from applications. This means that Prometheus will scrape or watch endpoints to pull metrics from.
+The following job configuration will enable prometheus installation to scrape from CDCSDK Server
+
+
+```
+- job_name: 'cdcsdk-server-metrics'
+   metrics_path: '/q/metrics'
+   scrape_interval: 3s
+   static_configs:
+     - targets: ['HOST:8080']
 ```

--- a/cdcsdk-server/cdcsdk-server-bom/pom.xml
+++ b/cdcsdk-server/cdcsdk-server-bom/pom.xml
@@ -49,7 +49,7 @@
                 <artifactId>kafka-clients</artifactId>
                 <version>${version.kafka}</version>
             </dependency>
-    
+
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
@@ -81,6 +81,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+                <version>2.10.0.Final</version>
+            </dependency>
+
 
             <!-- Connectors -->
             <dependency>

--- a/cdcsdk-server/cdcsdk-server-core/pom.xml
+++ b/cdcsdk-server/cdcsdk-server-core/pom.xml
@@ -29,6 +29,14 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
 

--- a/cdcsdk-server/cdcsdk-server-core/src/main/java/com/yugabyte/cdcsdk/server/Metrics.java
+++ b/cdcsdk-server/cdcsdk-server-core/src/main/java/com/yugabyte/cdcsdk/server/Metrics.java
@@ -1,0 +1,29 @@
+package com.yugabyte.cdcsdk.server;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Dependent
+public class Metrics {
+    @Inject
+    MeterRegistry meterRegistry;
+
+    public static final String bytesWritten = "cdcsdk.sink.total.bytesWritten";
+    public static final String recordsWritten = "cdcsdk.sink.total.recordsWritten";
+
+    public Counter get(String counterName) {
+        return meterRegistry.counter(bytesWritten);
+    }
+
+    public void apply(long numRecords, long numSize) {
+        meterRegistry.counter(bytesWritten).increment(numSize);
+        meterRegistry.counter(recordsWritten).increment(numRecords);
+    }
+
+    public MeterRegistry registry() {
+        return meterRegistry;
+    }
+}

--- a/cdcsdk-server/cdcsdk-server-core/src/main/java/io/debezium/server/BaseChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-core/src/main/java/io/debezium/server/BaseChangeConsumer.java
@@ -16,6 +16,8 @@ import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.yugabyte.cdcsdk.server.Metrics;
+
 import io.debezium.DebeziumException;
 
 /**
@@ -33,22 +35,28 @@ public class BaseChangeConsumer {
     @Inject
     Instance<StreamNameMapper> customStreamNameMapper;
 
+    @Inject
+    protected Metrics metrics;
+
     @PostConstruct
     void init() {
         if (customStreamNameMapper.isResolvable()) {
             streamNameMapper = customStreamNameMapper.get();
         }
         LOGGER.info("Using '{}' stream name mapper", streamNameMapper);
+        metrics.apply(0, 0);
+        LOGGER.info("Initialized Consumer Metrics");
     }
 
     /**
      * Get a subset of the configuration properties that matches the given prefix.
-     * 
-     * @param config    The global configuration object to extract the subset from.
-     * @param prefix    The prefix to filter property names.
-     * 
-     * @return          A subset of the original configuration properties containing property names
-     *                  without the prefix.
+     *
+     * @param config The global configuration object to extract the subset from.
+     * @param prefix The prefix to filter property names.
+     *
+     * @return A subset of the original configuration properties containing property
+     *         names
+     *         without the prefix.
      */
     protected Map<String, Object> getConfigSubset(Config config, String prefix) {
         final Map<String, Object> ret = new HashMap<>();

--- a/cdcsdk-server/cdcsdk-server-core/src/main/java/io/debezium/server/ConnectorLifecycle.java
+++ b/cdcsdk-server/cdcsdk-server-core/src/main/java/io/debezium/server/ConnectorLifecycle.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.server;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -15,12 +16,15 @@ import org.eclipse.microprofile.health.Liveness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.yugabyte.cdcsdk.server.Metrics;
+
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.server.events.ConnectorCompletedEvent;
 import io.debezium.server.events.ConnectorStartedEvent;
 import io.debezium.server.events.ConnectorStoppedEvent;
 import io.debezium.server.events.TaskStartedEvent;
 import io.debezium.server.events.TaskStoppedEvent;
+import io.micrometer.core.instrument.Gauge;
 
 /**
  * The server lifecycle listener that published CDI events based on the lifecycle changes and also provides
@@ -51,6 +55,14 @@ public class ConnectorLifecycle implements HealthCheck, DebeziumEngine.Connector
 
     @Inject
     Event<ConnectorCompletedEvent> connectorCompletedEvent;
+
+    @Inject
+    Metrics metrics;
+
+    @PostConstruct
+    public void init() {
+        Gauge.builder("cdcsdk.server.health", this::getStatusCode).strongReference(true).register(metrics.registry());
+    }
 
     @Override
     public void connectorStarted() {
@@ -90,4 +102,7 @@ public class ConnectorLifecycle implements HealthCheck, DebeziumEngine.Connector
         return HealthCheckResponse.named("cdcsdk-server").status(live).build();
     }
 
+    private int getStatusCode() {
+        return live ? 0 : 1;
+    }
 }

--- a/cdcsdk-server/cdcsdk-server-core/src/main/java/io/debezium/server/ConnectorLifecycle.java
+++ b/cdcsdk-server/cdcsdk-server-core/src/main/java/io/debezium/server/ConnectorLifecycle.java
@@ -87,7 +87,7 @@ public class ConnectorLifecycle implements HealthCheck, DebeziumEngine.Connector
     @Override
     public HealthCheckResponse call() {
         LOGGER.trace("Healthcheck called - live = '{}'", live);
-        return HealthCheckResponse.named("debezium").status(live).build();
+        return HealthCheckResponse.named("cdcsdk-server").status(live).build();
     }
 
 }

--- a/cdcsdk-server/pom.xml
+++ b/cdcsdk-server/pom.xml
@@ -52,6 +52,14 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Use [Micrometer](https://micrometer.io) the preferred metrics library for Quarkus applications. Create the following metrics:
* cdcsdk_server_health
* cdcsdk_sink_totalBytesWritten
* cdcsdk_server_totalRecordsWritten

Instrument NullStreamChangeConsumer to track these metrics.

Bugs:
* Store and list all engines in ServerApp
* Add kafka/confluent to docs and note on S3 restrictions