### PR TITLE
Create a docker image of CDCSDK Server for release tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,3 +30,12 @@ up new credentials**
     mvn integration-test
     # Run a specific integration test
     mvn integration-test -Dit.test=HttpIT -DfailIfNoTests=false
+
+
+## Run Release Tests
+
+The below command will create a docker image of CDCSDK Server and run
+integration tests in cdcsdk-testing
+
+
+   mvn integration-test -Drun.releaseTests

--- a/cdcsdk-parent/pom.xml
+++ b/cdcsdk-parent/pom.xml
@@ -395,6 +395,11 @@
         </profile>
         <profile>
             <id>releaseTests</id>
+            <activation>
+                <property>
+                    <name>run.releaseTests</name>
+                </property>
+            </activation>
             <properties>
                 <skipRelTests>false</skipRelTests>
                 <skipITs>true</skipITs>

--- a/cdcsdk-server/cdcsdk-server-dist/Dockerfile
+++ b/cdcsdk-server/cdcsdk-server-dist/Dockerfile
@@ -1,0 +1,53 @@
+FROM registry.access.redhat.com/ubi8/openjdk-11
+
+LABEL maintainer="Yugabyte"
+
+#
+# Set the version, home directory, and MD5 hash.
+#
+ENV SERVER_HOME=/cdcsdk-server
+
+#
+# Create a directory for Debezium Server
+#
+USER root
+RUN microdnf -y install gzip && \
+    microdnf clean all && \
+    mkdir $SERVER_HOME && \
+    chmod 755 $SERVER_HOME
+
+#
+# Change ownership and switch user
+#
+RUN chown -R jboss $SERVER_HOME && \
+    chgrp -R jboss $SERVER_HOME
+USER jboss
+
+RUN mkdir $SERVER_HOME/conf && \
+    mkdir $SERVER_HOME/data
+
+#
+# Download and install Debezium Server
+#
+COPY target/cdcsdk-server-dist-*.tar.gz /tmp/cdcsdk-server.tar.gz
+
+#
+# Verify the contents and then install ...
+#
+RUN tar xzf /tmp/cdcsdk-server.tar.gz -C $SERVER_HOME --strip-components 1
+
+#
+# Allow random UID to use Debezium Server
+#
+RUN chmod -R g+w,o+w $SERVER_HOME
+
+# Set the working directory to the Debezium Server home directory
+WORKDIR $SERVER_HOME
+
+#
+# Expose the ports and set up volumes for the data, transaction log, and configuration
+#
+EXPOSE 8080
+VOLUME ["/cdcsdk-server/conf","/cdcsdk-server/data"]
+
+CMD ["/cdcsdk-server/run.sh"]

--- a/cdcsdk-server/cdcsdk-server-dist/pom.xml
+++ b/cdcsdk-server/cdcsdk-server-dist/pom.xml
@@ -45,6 +45,9 @@
             <id>assembly</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>run.releaseTests</name>
+                </property>
             </activation>
             <dependencies>
                 <dependency>
@@ -130,7 +133,7 @@
                         <executions>
                             <execution>
                                 <id>default</id>
-                                <phase>package</phase>
+                                <phase>pre-integration-test</phase>
                                 <goals>
                                     <goal>single</goal>
                                 </goals>
@@ -142,6 +145,30 @@
                                     </descriptors>
                                     <tarLongFileMode>posix</tarLongFileMode>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>yugabyte/cdcsdk-server:${project.version}</name>
+                                    <build>
+                                        <contextDir>${project.basedir}</contextDir>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/cdcsdk-server/cdcsdk-server-dist/src/main/resources/assemblies/server-distribution.xml
+++ b/cdcsdk-server/cdcsdk-server-dist/src/main/resources/assemblies/server-distribution.xml
@@ -5,7 +5,6 @@
   <id>distribution</id>
   <formats>
     <format>tar.gz</format>
-    <format>zip</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <dependencySets>

--- a/cdcsdk-testing/pom.xml
+++ b/cdcsdk-testing/pom.xml
@@ -37,12 +37,12 @@
 
   <dependencies>
     <dependency>
-        <groupId>io.debezium</groupId>
+        <groupId>com.yugabyte</groupId>
         <artifactId>cdcsdk-server-core</artifactId>
         <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.debezium</groupId>
+      <groupId>com.yugabyte</groupId>
       <artifactId>cdcsdk-server-s3</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -84,14 +84,14 @@
 
     <!-- Testing -->
     <dependency>
-      <groupId>io.debezium</groupId>
+      <groupId>com.yugabyte</groupId>
       <artifactId>cdcsdk-server-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.debezium</groupId>
+      <groupId>com.yugabyte</groupId>
       <artifactId>cdcsdk-server-s3</artifactId>
       <type>test-jar</type>
       <scope>test</scope>

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
@@ -28,7 +28,7 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yugabyte.cdcsdk.sink.s3.FlushingChangeConsumer;
+import com.yugabyte.cdcsdk.sink.s3.S3ChangeConsumer;
 import com.yugabyte.cdcsdk.sink.s3.S3Storage;
 import com.yugabyte.cdcsdk.sink.s3.config.S3SinkConnectorConfig;
 import com.yugabyte.cdcsdk.sink.s3.util.S3Utils;
@@ -77,7 +77,7 @@ public class S3ConsumerRelIT {
         // {id int primary key, first_name varchar(30), last_name varchar(50), days_worked double precision}
         // CREATE TABLE IF NOT EXISTS test_table (id int primary key, first_name varchar(30), last_name varchar(50), days_worked double precision);
         testConfig = new ConfigSourceS3();
-        s3Config = new S3SinkConnectorConfig(testConfig.getMapSubset(FlushingChangeConsumer.PROP_SINK_PREFIX));
+        s3Config = new S3SinkConnectorConfig(testConfig.getMapSubset(S3ChangeConsumer.PROP_SINK_PREFIX));
 
         // todo vaibhav: add configuration from a resource file if possible
         storage = new S3Storage(s3Config, "");

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,11 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${version.build-helper.plugin}</version>
                 </plugin>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.40.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -301,6 +306,21 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>yugabyte/cdcsdk-server:${project.version}</name>
+                            <build>
+                                <dockerFile>Dockerfile</dockerFile>
+                            </build>
+                            </image>
+                        </images>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Docker image is created in pre-integration-test stage. The Dockerfile
uses the assembled tar.gz to create it. This stage can be activated
with:

    mvn integration-test -Drun.releaseTests