### PR TITLE
Fix for test failure because of incorrect config filtering

### DIFF
--- a/cdcsdk-server/cdcsdk-server-s3/src/main/java/com/yugabyte/cdcsdk/sink/s3/S3ChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-s3/src/main/java/com/yugabyte/cdcsdk/sink/s3/S3ChangeConsumer.java
@@ -35,7 +35,7 @@ public class S3ChangeConsumer extends BaseChangeConsumer
         implements DebeziumEngine.ChangeConsumer<ChangeEvent<Object, Object>> {
 
     public static final String PROP_SINK_PREFIX = "cdcsdk.sink.";
-    protected static final String PROP_S3_PREFIX = PROP_SINK_PREFIX + "s3.";
+    public static final String PROP_S3_PREFIX = PROP_SINK_PREFIX + "s3.";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3ChangeConsumer.class);
 

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
@@ -77,7 +77,7 @@ public class S3ConsumerRelIT {
         // {id int primary key, first_name varchar(30), last_name varchar(50), days_worked double precision}
         // CREATE TABLE IF NOT EXISTS test_table (id int primary key, first_name varchar(30), last_name varchar(50), days_worked double precision);
         testConfig = new ConfigSourceS3();
-        s3Config = new S3SinkConnectorConfig(testConfig.getMapSubset(S3ChangeConsumer.PROP_SINK_PREFIX));
+        s3Config = new S3SinkConnectorConfig(testConfig.getMapSubset(S3ChangeConsumer.PROP_S3_PREFIX));
 
         // todo vaibhav: add configuration from a resource file if possible
         storage = new S3Storage(s3Config, "");


### PR DESCRIPTION
The release test started to fail because it was unable to filter out the proper sink configuration from the provided configuration properties. On investigation, it was found that the issue was due to an incorrect filtering prefix specified.

This PR aims to fix the same issue by changing the filtering prefix to the correct value.