### PR TITLE
Properly set configuration for 'value.converter' when provided in application.properties

### DIFF
--- a/cdcsdk-server/cdcsdk-server-core/src/main/java/com/yugabyte/cdcsdk/server/ServerApp.java
+++ b/cdcsdk-server/cdcsdk-server-core/src/main/java/com/yugabyte/cdcsdk/server/ServerApp.java
@@ -82,10 +82,9 @@ public class ServerApp {
     private static final String PROP_SINK_PREFIX = PROP_PREFIX + "sink.";
     private static final String PROP_FORMAT_PREFIX = PROP_SERVER_PREFIX + "format.";
     private static final String PROP_KEY_FORMAT_PREFIX = PROP_FORMAT_PREFIX + "key.";
+    private static final String PROP_CONVERTER_KEY_PREFIX = PROP_KEY_FORMAT_PREFIX + "converter.";
     private static final String PROP_VALUE_FORMAT_PREFIX = PROP_FORMAT_PREFIX + "value.";
     private static final String PROP_CONVERTER_VALUE_PREFIX = PROP_VALUE_FORMAT_PREFIX + "converter.";
-    private static final String PROP_SCHEMAS_CONVERTER_PREFIX = PROP_CONVERTER_VALUE_PREFIX + "schemas.";
-    private static final String PROP_ENABLE_SCHEMAS_PREFIX = PROP_SCHEMAS_CONVERTER_PREFIX + "enable";
 
     private static final String PROP_SINK_TYPE = PROP_SINK_PREFIX + "type";
     private static final String PROP_KEY_FORMAT = PROP_FORMAT_PREFIX + "key";
@@ -154,13 +153,9 @@ public class ServerApp {
         configToProperties(config, props, PROP_FORMAT_PREFIX, "value.converter.");
         configToProperties(config, props, PROP_KEY_FORMAT_PREFIX, "key.converter.");
         configToProperties(config, props, PROP_VALUE_FORMAT_PREFIX, "value.converter.");
+        configToProperties(config, props, PROP_CONVERTER_VALUE_PREFIX, "value.converter.");
+        configToProperties(config, props, PROP_CONVERTER_KEY_PREFIX, "key.converter.");
         final Optional<String> transforms = config.getOptionalValue(PROP_TRANSFORMS, String.class);
-
-        final Optional<Boolean> schemas_enable = config.getOptionalValue(PROP_ENABLE_SCHEMAS_PREFIX, Boolean.class);
-        if (schemas_enable.isPresent()) {
-            LOGGER.info("Setting value for config: 'value.converter.schemas.enable', to: " + schemas_enable.get().toString());
-            props.setProperty("value.converter.schemas.enable", schemas_enable.get().toString());
-        }
 
         if (transforms.isPresent()) {
             LOGGER.debug("Transforms Setting: -{}-", transforms.get());


### PR DESCRIPTION
Previously, the value for config: "cdcsdk.server.format.value.converter.schemas.enable" was not being set even provided in the application.proerties file. 
This was because we were adding the prefix: "transaforms" through the line:
`configToProperties(config, props, PROP_TRANSFORMS_PREFIX, "transforms.");`

Now we have added a check to see if a value for this config was provided and set the value for property: "value.converter.schemas.enable"