### PR TITLE
Improve startup waiting strategy for CDCSDK container in release time

### DIFF
--- a/cdcsdk-engine/src/main/java/com/yugabyte/cdcsdk/engine/MTEngine.java
+++ b/cdcsdk-engine/src/main/java/com/yugabyte/cdcsdk/engine/MTEngine.java
@@ -872,6 +872,7 @@ public final class MTEngine implements DebeziumEngine<SourceRecord> {
 
                     recordsSinceLastCommit = 0;
                     Throwable handlerError = null;
+                    LOGGER.info("BEGIN RECORD PROCESSING");
                     try {
                         timeOfLastCommitMillis = clock.currentTimeInMillis();
                         RecordCommitter committer = buildRecordCommitter(offsetWriter, task, commitTimeout);

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
@@ -12,14 +12,12 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,11 +106,6 @@ public class S3ConsumerRelIT {
         GenericContainer<?> cdcContainer = TestHelper.getCdcsdkContainer();
         cdcContainer.start();
 
-        // Wait for sometime for the cdcsdk-server container to be initialized properly
-        // TODO: This block is a major hack to wait for CDCSDK server to come
-        // up. Instead Test Containers should wait for health checks and then
-        // only continue.
-        Thread.sleep(90000);
         assertTrue(cdcContainer.isRunning());
 
         storage = new S3Storage(s3Config, "");

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/TestHelper.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/TestHelper.java
@@ -6,6 +6,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.YugabyteYSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import org.yb.client.AsyncYBClient;
 import org.yb.client.ListTablesResponse;
@@ -144,6 +146,9 @@ public class TestHelper {
         // By the time this container is created, the table should be there in the database already
         cdcsdkContainer.withEnv(getConfigMap());
         cdcsdkContainer.withNetwork(containerNetwork);
+        cdcsdkContainer.withExposedPorts(8080);
+        cdcsdkContainer.waitingFor(Wait.forLogMessage(".*BEGIN RECORD PROCESSING.*\\n", 1));
+        cdcsdkContainer.withStartupTimeout(Duration.ofSeconds(120));
 
         return cdcsdkContainer;
     }


### PR DESCRIPTION
Put a marker in logs for when CDCSDK server is ready. Use waitFor
strategy from test containers to wait for the line before starting the
test.