### PR TITLE
Addition of integration test with a Elasticsearch sink

### DIFF
--- a/cdcsdk-server/cdcsdk-server-kafka/src/main/java/io/debezium/server/kafka/KafkaChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-kafka/src/main/java/io/debezium/server/kafka/KafkaChangeConsumer.java
@@ -98,7 +98,8 @@ public class KafkaChangeConsumer extends BaseChangeConsumer implements DebeziumE
 
                 if (key != null) {
                     this.metrics.get(Metrics.bytesWritten).increment(
-                            key.getBytes().length);
+                            key.getBytes().length
+                    );
                 }
                 if (value != null) {
                     this.metrics.get(Metrics.bytesWritten).increment(value.getBytes().length);

--- a/cdcsdk-server/cdcsdk-server-kafka/src/main/java/io/debezium/server/kafka/KafkaChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-kafka/src/main/java/io/debezium/server/kafka/KafkaChangeConsumer.java
@@ -98,8 +98,7 @@ public class KafkaChangeConsumer extends BaseChangeConsumer implements DebeziumE
 
                 if (key != null) {
                     this.metrics.get(Metrics.bytesWritten).increment(
-                            key.getBytes().length
-                    );
+                            key.getBytes().length);
                 }
                 if (value != null) {
                     this.metrics.get(Metrics.bytesWritten).increment(value.getBytes().length);

--- a/cdcsdk-testing/pom.xml
+++ b/cdcsdk-testing/pom.xml
@@ -143,13 +143,19 @@
         <scope>test</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.elasticsearch.client/elasticsearch-rest-client -->
-  <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
-      <version>8.3.2</version>
-      <scope>test</scope>
-  </dependency>
-
+    <dependency>
+        <groupId>org.elasticsearch.client</groupId>
+        <artifactId>elasticsearch-rest-client</artifactId>
+        <version>8.3.2</version>
+        <scope>test</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.json/json -->
+    <dependency>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>20220320</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdcsdk-testing/pom.xml
+++ b/cdcsdk-testing/pom.xml
@@ -112,6 +112,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>1.17.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
       <version>1.17.3</version>
       <scope>test</scope>

--- a/cdcsdk-testing/pom.xml
+++ b/cdcsdk-testing/pom.xml
@@ -142,6 +142,14 @@
         <version>4.2.0</version>
         <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.elasticsearch.client/elasticsearch-rest-client -->
+  <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <version>8.3.2</version>
+      <scope>test</scope>
+  </dependency>
+
   </dependencies>
 
   <build>

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/ElasticsearchSinkConsumerIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/ElasticsearchSinkConsumerIT.java
@@ -1,11 +1,185 @@
 package com.yugabyte.cdcsdk.testing;
 
+import java.io.ByteArrayInputStream;
+import java.net.InetAddress;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.util.Iterator;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.NodeSelector;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.testing.testcontainers.ConnectorConfiguration;
+import io.debezium.testing.testcontainers.DebeziumContainer;
 
 public class ElasticsearchSinkConsumerIT {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchSinkConsumerIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchSinkConsumerIT.class);
+    private static final String ELASTIC_SEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:7.3.0";
+    private static final String KAFKA_CONNECT_IMAGE = "quay.io/yugabyte/connect-jdbc-es:1.0";
+    private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:6.2.1";
 
-  private static KafkaContainer kafkaContainer;
+    private static final String createTableSql = "CREATE TABLE IF NOT EXISTS test_table (id int primary key, first_name varchar(30), last_name varchar(50), days_worked double precision)";
+    private static final String dropTableSql = "DROP TABLE test_table";
+
+    private static KafkaContainer kafkaContainer;
+    private static ElasticsearchContainer esContainer;
+    private static DebeziumContainer kafkaConnectContainer;
+    private static GenericContainer<?> cdcsdkContainer;
+
+    private static ConnectorConfiguration sinkConfig;
+    private static RestClient restClient;
+
+    private static Network containerNetwork;
+
+    private static final NodeSelector INGEST_NODE_SELECTOR = nodes -> {
+        final Iterator<Node> iterator = nodes.iterator();
+        while (iterator.hasNext()) {
+            Node node = iterator.next();
+
+            if (node.getRoles() != null && node.getRoles().isIngest() == false) {
+                iterator.remove();
+            }
+        }
+    };
+
+    private static ConnectorConfiguration getEsSinkConfiguration(String connectionUrl) throws Exception {
+        return ConnectorConfiguration.create()
+                .with("connector.class", "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector")
+                .with("tasks.max", 1)
+                .with("topics", "dbserver1.public.test_table")
+                .with("connection.url", connectionUrl)
+                .with("transforms", "key")
+                .with("transforms.key.type", "org.apache.kafka.connect.transforms.ExtractField$Key")
+                .with("transforms.key.field", "id")
+                .with("key.ignore", "false")
+                .with("type.name", "test_table");
+    }
+
+    public static SSLContext createContextFromCaCert(byte[] certAsBytes) {
+        try {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            Certificate trustedCa = factory.generateCertificate(new ByteArrayInputStream(certAsBytes));
+            KeyStore trustStore = KeyStore.getInstance("pkcs12");
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("ca", trustedCa);
+            SSLContextBuilder sslContextBuilder = SSLContexts.custom().loadTrustMaterial(trustStore, null);
+            return sslContextBuilder.build();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        containerNetwork = Network.newNetwork();
+
+        kafkaContainer = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE)).withNetworkAliases("kafka").withNetwork(containerNetwork);
+
+        kafkaConnectContainer = new DebeziumContainer(KAFKA_CONNECT_IMAGE).withKafka(kafkaContainer).dependsOn(kafkaContainer).withNetwork(containerNetwork);
+
+        esContainer = new ElasticsearchContainer(ELASTIC_SEARCH_IMAGE).withNetwork(containerNetwork).withExposedPorts(9200)
+                .withPassword("password");
+        // esContainer.setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*\"message\":\"started\".*"));
+        esContainer.getEnvMap().remove("xpack.security.enabled");
+        esContainer.withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
+        kafkaContainer.start();
+        kafkaConnectContainer.start();
+        try {
+            esContainer.start();
+        }
+        catch (Exception e) {
+            System.out.println(esContainer.getLogs());
+            throw e;
+        }
+
+        System.out.println();
+        // Sleep for enough time so as to analyze the ES logs
+        Thread.sleep(50000);
+
+        TestHelper.setHost(InetAddress.getLocalHost().getHostAddress());
+        TestHelper.setBootstrapServer(kafkaContainer.getNetworkAliases().get(0) + ":9092");
+
+        sinkConfig = getEsSinkConfiguration(InetAddress.getLocalHost().getHostAddress() + ":" + esContainer.getMappedPort(9200));
+        kafkaConnectContainer.registerConnector("es-sink-connector", sinkConfig);
+
+        TestHelper.execute(createTableSql);
+
+        cdcsdkContainer = TestHelper.getCdcsdkContainerForKafkaSink();
+        cdcsdkContainer.withNetwork(containerNetwork);
+        cdcsdkContainer.start();
+    }
+
+    @Before
+    public void before() throws Exception {
+    }
+
+    @After
+    public void after() throws Exception {
+
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        esContainer.stop();
+        kafkaConnectContainer.stop();
+        cdcsdkContainer.stop();
+        kafkaContainer.stop();
+        TestHelper.execute(dropTableSql);
+    }
+
+    @Test
+    public void testElasticsearchSink() throws Exception {
+        System.out.println("Container stats: ");
+        System.out.println("Kafka: " + kafkaContainer.isRunning());
+        System.out.println("Kafka Connect: " + kafkaConnectContainer.isRunning());
+        System.out.println("ElasticSearch: " + esContainer.isRunning());
+
+        // byte[] certAsBytes = esContainer.copyFileFromContainer("/usr/share/elasticsearch/config/certs/http_ca.crt", InputStream::readAllBytes);
+        HttpHost httpHost = new HttpHost(InetAddress.getLocalHost().getHostAddress(), esContainer.getMappedPort(9200), "http");
+
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("elastic", "password"));
+
+        final RestClientBuilder restClientBuilder = RestClient.builder(httpHost);
+
+        restClientBuilder.setHttpClientConfigCallback(clientBuilder -> {
+            // clientBuilder.setSSLContext(createContextFromCaCert(certAsBytes));
+            clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+            return clientBuilder;
+        });
+
+        restClientBuilder.setNodeSelector(INGEST_NODE_SELECTOR);
+
+        restClient = restClientBuilder.build();
+
+        Response response = restClient.performRequest(new Request("GET", "/_cluster/health"));
+        System.out.println(response.toString());
+    }
 }

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/ElasticsearchSinkConsumerIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/ElasticsearchSinkConsumerIT.java
@@ -1,0 +1,11 @@
+package com.yugabyte.cdcsdk.testing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+
+public class ElasticsearchSinkConsumerIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchSinkConsumerIT.class);
+
+  private static KafkaContainer kafkaContainer;
+}

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/PostgresSinkConsumerIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/PostgresSinkConsumerIT.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.consumer.*;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -40,7 +39,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.debezium.testing.testcontainers.*;
 
-@Disabled
+/**
+ * Release test that verifies basic reading from a YugabyteDB database and
+ * writing to Kafka and then further to a PostgreSQL sink database
+ *
+ * @author Isha Amoncar
+ */
 public class PostgresSinkConsumerIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresSinkConsumerIT.class);
     private KafkaConsumer<String, JsonNode> consumer;

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/PostgresSinkConsumerIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/PostgresSinkConsumerIT.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.debezium.testing.testcontainers.*;
 
+@Disabled
 public class PostgresSinkConsumerIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresSinkConsumerIT.class);
     private KafkaConsumer<String, JsonNode> consumer;

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
@@ -40,13 +40,12 @@ import com.yugabyte.cdcsdk.sink.s3.config.S3SinkConnectorConfig;
 import com.yugabyte.cdcsdk.sink.s3.util.S3Utils;
 
 /**
- * Release test that verifies basic reading from PostgreSQL database and
+ * Release test that verifies basic reading from a YugabyteDB database and
  * writing to S3
  *
  * @author Rajat Venkatesh
  */
 
-@Disabled
 public class S3ConsumerRelIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3ConsumerRelIT.class);
 

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +46,7 @@ import com.yugabyte.cdcsdk.sink.s3.util.S3Utils;
  * @author Rajat Venkatesh
  */
 
+@Disabled
 public class S3ConsumerRelIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3ConsumerRelIT.class);
 

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/TestHelper.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/TestHelper.java
@@ -1,23 +1,31 @@
 package com.yugabyte.cdcsdk.testing;
 
-// import static org.junit.jupiter.api.Assertions.*;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.yb.client.AsyncYBClient;
 import org.yb.client.ListTablesResponse;
 import org.yb.client.YBClient;
 import org.yb.client.YBTable;
 import org.yb.master.MasterDdlOuterClass.ListTablesResponsePB.TableInfo;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.yugabyte.cdcsdk.testing.util.CdcsdkContainer;
 
 public class TestHelper {
@@ -26,6 +34,8 @@ public class TestHelper {
     private static int MASTER_PORT = 7100;
     private static String BOOTSTRAP_SERVER = "127.0.0.1:9092";
     private static Network containerNetwork;
+
+    private static final String ELASTIC_SEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:7.3.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestHelper.class);
 
@@ -105,6 +115,16 @@ public class TestHelper {
                 .buildForKafkaSink();
     }
 
+    public static ElasticsearchContainer getElasticsearchContainer(Network containeNetwork) throws Exception {
+        return new ElasticsearchContainer(ELASTIC_SEARCH_IMAGE)
+                .withNetwork(containerNetwork)
+                .withEnv("http.host", "0.0.0.0")
+                .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+                .withEnv("transport.host", "127.0.0.1")
+                .withExposedPorts(9200)
+                .withPassword("password");
+    }
+
     public static void execute(String sqlQuery) throws Exception {
         try (Connection conn = getConnection()) {
             Statement st = conn.createStatement();
@@ -124,5 +144,32 @@ public class TestHelper {
             LOGGER.error("Error executing query: " + sqlQuery, e);
             throw e;
         }
+    }
+
+    public static KafkaConsumer<String, JsonNode> getKafkaConsumer(String bootstrapServers) throws Exception {
+        Properties props = new Properties();
+        props.put("bootstrap.servers", bootstrapServers);
+        props.put("group.id", "testapp");
+        props.put("enable.auto.commit", "true");
+        props.put("auto.commit.interval.ms", "1000");
+        props.put("session.timeout.ms", "30000");
+        props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("value.deserializer", "org.apache.kafka.connect.json.JsonDeserializer");
+        return new KafkaConsumer<>(props);
+    }
+
+    public static boolean waitTillKafkaHasRecords(KafkaConsumer<String, JsonNode> kConsumer, List<String> topics) throws Exception {
+        kConsumer.subscribe(topics);
+        kConsumer.seekToBeginning(kConsumer.assignment());
+        ConsumerRecords<String, JsonNode> records = kConsumer.poll(Duration.ofSeconds(15));
+
+        return records.count() != 0;
+    }
+
+    public static String executeShellCommand(String command) throws Exception {
+        Process process = Runtime.getRuntime().exec(command);
+        String stdOutput = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
+        process.destroy();
+        return stdOutput;
     }
 }

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/util/CdcsdkContainer.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/util/CdcsdkContainer.java
@@ -184,7 +184,7 @@ public class CdcsdkContainer {
         GenericContainer<?> cdcsdkContainer = new GenericContainer<>(cdcsdkContainerImageName);
         cdcsdkContainer.withEnv(getConfigMapForKafka());
         cdcsdkContainer.withExposedPorts(8080);
-        cdcsdkContainer.waitingFor(Wait.forLogMessage(".*BEGIN RECORD PROCESSING.*\\n", 1));
+        cdcsdkContainer.waitingFor(Wait.forLogMessage(".*Bootstrapping the tablet.*\\n", 1));
         cdcsdkContainer.withStartupTimeout(Duration.ofSeconds(120));
 
         return cdcsdkContainer;
@@ -194,7 +194,7 @@ public class CdcsdkContainer {
         GenericContainer<?> cdcsdkContainer = new GenericContainer<>(cdcsdkContainerImageName);
         cdcsdkContainer.withEnv(getConfigMapForS3());
         cdcsdkContainer.withExposedPorts(8080);
-        cdcsdkContainer.waitingFor(Wait.forLogMessage(".*BEGIN RECORD PROCESSING.*\\n", 1));
+        cdcsdkContainer.waitingFor(Wait.forLogMessage(".*Bootstrapping the tablet.*\\n", 1));
         cdcsdkContainer.withStartupTimeout(Duration.ofSeconds(120));
 
         return cdcsdkContainer;


### PR DESCRIPTION
This PR aims to add an integration test which verifies the end-to-end CDC pipeline for the Elasticsearch sink using CDCSDK server. The data flow is as per the following:

```
YugabyteDB --> CDCSDK server --> Kafka --> Elasticsearch
```