### PR TITLE
Tests to validate pipeline integrity after Kafka and Kafka Connect restarts

### DIFF
--- a/cdcsdk-testing/pom.xml
+++ b/cdcsdk-testing/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-testing-testcontainers</artifactId>
-      <version>1.9.4.Final</version>
+      <version>1.9.5.Final</version>
       <scope>test</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.zaxxer/HikariCP -->

--- a/cdcsdk-testing/pom.xml
+++ b/cdcsdk-testing/pom.xml
@@ -166,6 +166,12 @@
         <version>3.2.0</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>5.8.1</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/KafkaRestartIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/KafkaRestartIT.java
@@ -158,8 +158,8 @@ public class KafkaRestartIT extends CdcsdkTestBase {
 
     @Test
     public void insertRecordsWhileKafkaIsDown() throws Exception {
-        sinkConfig = pgHelper.getJdbcSinkConfiguration(postgresContainer, "id");
-        kafkaConnectContainer.registerConnector("jdbc-sink-kafka-down", sinkConfig);
+        // sinkConfig = pgHelper.getJdbcSinkConfiguration(postgresContainer, "id");
+        // kafkaConnectContainer.registerConnector("jdbc-sink-kafka-down", sinkConfig);
         int rowsToBeInsertedBeforeStopping = 5;
         ybHelper.insertBulk(0, rowsToBeInsertedBeforeStopping);
 
@@ -167,13 +167,15 @@ public class KafkaRestartIT extends CdcsdkTestBase {
         pgHelper.waitTillRecordsAreVerified(rowsToBeInsertedBeforeStopping, 10000);
 
         // Stop the Kafka process
-        dockerClient.stopContainerCmd(kafkaContainer.getContainerId()).exec();
+        kafkaContainer.getDockerClient().stopContainerCmd(kafkaContainer.getContainerId()).exec();
+        // dockerClient.stopContainerCmd(kafkaContainer.getContainerId()).exec();
 
         // Insert more records - this will make the total records as 15
         ybHelper.insertBulk(rowsToBeInsertedBeforeStopping, 15);
 
         // Start Kafka process
-        dockerClient.startContainerCmd(kafkaContainer.getContainerId()).exec();
+        kafkaContainer.getDockerClient().startContainerCmd(kafkaContainer.getContainerId()).exec();
+        // dockerClient.startContainerCmd(kafkaContainer.getContainerId()).exec();
 
         // Thread.sleep(5000);
         // Path kafkaLogPath = Paths.get("/home/ec2-user/kafka-log.txt");
@@ -181,7 +183,7 @@ public class KafkaRestartIT extends CdcsdkTestBase {
         // System.out.println("Wrote log files");
 
         pgHelper.waitTillRecordsAreVerified(15, 30000);
-        kafkaConnectContainer.deleteConnector("jdbc-sink-kafka-down");
+        // kafkaConnectContainer.deleteConnector("jdbc-sink-kafka-down");
     }
 
     /**

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/KafkaRestartIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/KafkaRestartIT.java
@@ -1,0 +1,123 @@
+package com.yugabyte.cdcsdk.testing;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.yugabyte.cdcsdk.testing.util.CdcsdkTestBase;
+import com.yugabyte.cdcsdk.testing.util.UtilStrings;
+
+import io.debezium.testing.testcontainers.ConnectorConfiguration;
+
+/**
+ * Release tests that verify the integrity of the pipeline in case Kafka restarts or goes down
+ * for any reason
+ * 
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class KafkaRestartIT extends CdcsdkTestBase {
+    private static final String SINK_CONNECTOR_NAME = "jdbc-sink";
+
+    private static ConnectorConfiguration sinkConfig;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        initializeContainers();
+
+        kafkaConnectContainer.withEnv("CONNECT_SESSION_TIMEOUT_MS", "120000");
+        kafkaContainer.start();
+        kafkaConnectContainer.start();
+        postgresContainer.start();
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(20))
+                .until(() -> postgresContainer.isRunning());
+
+        initHelpers();
+    }
+
+    @BeforeEach
+    public void beforeEachTest() throws Exception {
+        // Create table in source database
+        ybHelper.execute(UtilStrings.getCreateTableYBStmt(DEFAULT_TABLE_NAME, 10));
+
+        // Start the cdcsdk container
+        cdcsdkContainer = kafkaHelper.getCdcsdkContainer(ybHelper, "public." + DEFAULT_TABLE_NAME, 10);
+        cdcsdkContainer.withNetwork(containerNetwork);
+        cdcsdkContainer.start();
+
+        // Register the sink connector
+        sinkConfig = pgHelper.getJdbcSinkConfiguration(postgresContainer, "id");
+        kafkaConnectContainer.registerConnector(SINK_CONNECTOR_NAME, sinkConfig);
+    }
+
+    @AfterEach
+    public void afterEachTest() throws Exception {
+        // Stop the cdcsdk container to prevent further unexpected behaviour
+        cdcsdkContainer.stop();
+
+        // Delete the sink connector
+        kafkaConnectContainer.deleteConnector(SINK_CONNECTOR_NAME);
+
+        // Delete the Kafka topic so that it can be again created/used by the next test
+        kafkaHelper.deleteTopicInKafka(pgHelper.getKafkaTopicName());
+
+        // Drop the tables
+        dropTablesAfterEachTest(DEFAULT_TABLE_NAME);
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        // Stop the running containers
+        postgresContainer.stop();
+        kafkaConnectContainer.stop();
+        kafkaContainer.stop();
+    }
+
+    @Test
+    public void restartKafkaAndVerifyPipelineIntegrity() throws Exception {
+        int rowsToBeInserted = 5;
+        for (int i = 0; i < rowsToBeInserted; ++i) {
+            ybHelper.execute(UtilStrings.getInsertStmt(DEFAULT_TABLE_NAME, i, "first_" + i, "last_" + i, 23.45));
+        }
+
+        // Wait for records to be replicated across Postgres sink
+        pgHelper.waitTillRecordsAreVerified(rowsToBeInserted, 10000);
+
+        restartKafkaContainer();
+
+        // Insert some more records after Kafka container is restarted
+        for (int i = 5; i < 15; ++i) {
+            ybHelper.execute(UtilStrings.getInsertStmt(DEFAULT_TABLE_NAME, i, "first_" + i, "last_" + i, 23.45));
+        }
+
+        Path kafkaLogPath = Paths.get("/home/ec2-user/kafka-log.txt");
+        Path kafkaConnectLogPath = Paths.get("/home/ec2-user/kafka-connect-log.txt");
+
+        Files.writeString(kafkaLogPath, kafkaContainer.getLogs(), StandardCharsets.UTF_8);
+        Files.writeString(kafkaConnectLogPath, kafkaConnectContainer.getLogs(), StandardCharsets.UTF_8);
+        System.out.println("Wrote the logs to the respective files");
+        pgHelper.waitTillRecordsAreVerified(15, 10000);
+
+        // Verify the record count in the sink
+        pgHelper.assertRecordCountInPostgres(15);
+    }
+
+    /**
+     * Helper function to restart the Kafka container
+     * @throws Exception if the container cannot be stopped or started after stopping
+     */
+    public void restartKafkaContainer() throws Exception {
+        kafkaContainer.stop();
+        kafkaContainer.start();
+    }
+
+}

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/KafkaRestartIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/KafkaRestartIT.java
@@ -10,11 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.containers.GenericContainer;
 
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.Ports;
-import com.github.dockerjava.api.model.Ports.Binding;
 import com.yugabyte.cdcsdk.testing.util.CdcsdkTestBase;
 import com.yugabyte.cdcsdk.testing.util.UtilStrings;
 

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/KafkaRestartIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/KafkaRestartIT.java
@@ -60,7 +60,7 @@ public class KafkaRestartIT extends CdcsdkTestBase {
 
         // Register the sink connector
         sinkConfig = pgHelper.getJdbcSinkConfiguration(postgresContainer, "id");
-        int mappedPort = getContainerMappedPortFor(kafkaConnectContainer, 8083);
+        int mappedPort = TestHelper.getContainerMappedPortFor(kafkaConnectContainer, 8083);
         TestHelper.registerConnector(String.format(CONNECTOR_URI, mappedPort), SINK_CONNECTOR_NAME, sinkConfig);
     }
 
@@ -70,7 +70,7 @@ public class KafkaRestartIT extends CdcsdkTestBase {
         cdcsdkContainer.stop();
 
         // Delete the sink connector
-        TestHelper.deleteConnector(String.format(CONNECTOR_URI, getContainerMappedPortFor(kafkaConnectContainer, 8083)) + SINK_CONNECTOR_NAME);
+        TestHelper.deleteConnector(String.format(CONNECTOR_URI, TestHelper.getContainerMappedPortFor(kafkaConnectContainer, 8083)) + SINK_CONNECTOR_NAME);
 
         // Delete the Kafka topic so that it can be again created/used by the next test
         kafkaHelper.deleteTopicInKafka(pgHelper.getKafkaTopicName());
@@ -173,11 +173,5 @@ public class KafkaRestartIT extends CdcsdkTestBase {
     public void restartKafkaContainer() throws Exception {
         kafkaContainer.getDockerClient().stopContainerCmd(kafkaContainer.getContainerId()).exec();
         kafkaContainer.getDockerClient().startContainerCmd(kafkaContainer.getContainerId()).exec();
-    }
-
-    private int getContainerMappedPortFor(GenericContainer<?> container, int port) {
-        Ports ports = container.getCurrentContainerInfo().getNetworkSettings().getPorts();
-        Binding[] binding = ports.getBindings().get(ExposedPort.tcp(port));
-        return Integer.valueOf(binding[0].getHostPortSpec());
     }
 }

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/MultiOpsPostgresSinkConsumerIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/MultiOpsPostgresSinkConsumerIT.java
@@ -97,9 +97,6 @@ public class MultiOpsPostgresSinkConsumerIT extends CdcsdkTestBase {
         pgHelper.waitTillRecordsAreVerified(0, 5000);
 
         pgHelper.assertRecordCountInPostgres(0);
-        // Sleep for 5 minutes to verify connector endpoints
-        System.out.println("Sleeping for 5 minutes");
-        Thread.sleep(300000);
     }
 
     @Test

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/MultiOpsPostgresSinkConsumerIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/MultiOpsPostgresSinkConsumerIT.java
@@ -97,7 +97,9 @@ public class MultiOpsPostgresSinkConsumerIT extends CdcsdkTestBase {
         pgHelper.waitTillRecordsAreVerified(0, 5000);
 
         pgHelper.assertRecordCountInPostgres(0);
-
+        // Sleep for 5 minutes to verify connector endpoints
+        System.out.println("Sleeping for 5 minutes");
+        Thread.sleep(300000);
     }
 
     @Test

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/TestHelper.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/TestHelper.java
@@ -2,6 +2,7 @@ package com.yugabyte.cdcsdk.testing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -14,6 +15,15 @@ import org.testcontainers.containers.GenericContainer;
 import com.yugabyte.cdcsdk.testing.util.CdcsdkContainer;
 import com.yugabyte.cdcsdk.testing.util.UtilStrings;
 import com.yugabyte.cdcsdk.testing.util.YBHelper;
+
+import io.debezium.testing.testcontainers.Connector;
+import io.debezium.testing.testcontainers.ConnectorConfiguration;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 public class TestHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestHelper.class);
@@ -66,5 +76,54 @@ public class TestHelper {
         assertEquals(firstNameCol, rs.getString(2));
         assertEquals(lastNameCol, rs.getString(3));
         assertEquals(daysWorkedCol, rs.getDouble(4));
+    }
+
+    /**
+     * Helper function to register connectors to the Kafka Connect container.
+     * 
+     * We cannot use {@code kafkaConnectContainer.registerConnector()} since the command didn't work
+     * after the containers were restarted i.e. in the backend the command was still referring to the
+     * mapped ports before the restart. 
+     * @param connectorsEndpoint connector URI
+     * @param connectorName name of the connector
+     * @param config configuration for the connector to be deployed
+     */
+    public static void registerConnector(String connectorsEndpoint, String connectorName, ConnectorConfiguration config) {
+        final OkHttpClient httpClient = new OkHttpClient();
+        final Connector connector = Connector.from(connectorName, config);
+
+        final RequestBody requestBody = RequestBody.create(connector.toJson(), MediaType.get("application/json; charset=utf-8"));
+        final Request request = new Request.Builder().url(connectorsEndpoint).post(requestBody).build();
+
+        try (final Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new RuntimeException("Cannot deploy the connector: " + connectorName);
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Error connecting to Debezium container", e);
+        }
+    }
+
+    public static String getJsonConfig(String connectorName, ConnectorConfiguration config) {
+        final Connector connector = Connector.from(connectorName, config);
+        return connector.toJson();
+    }
+
+    /**
+     * Helper function to delete connectors from Kafka Connect container.
+     * @param connectorUriString connector URI with connector name
+     */
+    public static void deleteConnector(String connectorUriString) {
+        final OkHttpClient httpClient = new OkHttpClient();
+        final Request request = new Request.Builder().url(connectorUriString).delete().build();
+        try (final Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new RuntimeException("Error deleting the connector");
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Error deleting the connector", e);
+        }
     }
 }

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/util/CdcsdkTestBase.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/util/CdcsdkTestBase.java
@@ -45,11 +45,13 @@ public class CdcsdkTestBase {
 
         kafkaContainer = new KafkaContainer(TestImages.KAFKA)
                 .withNetworkAliases("kafka")
+                .withReuse(true)
                 .withNetwork(containerNetwork);
 
         kafkaConnectContainer = new DebeziumContainer(TestImages.KAFKA_CONNECT)
                 .withKafka(kafkaContainer)
                 .dependsOn(kafkaContainer)
+                .withReuse(true)
                 .withNetwork(containerNetwork);
 
         postgresContainer = new PostgreSQLContainer<>(TestImages.POSTGRES)


### PR DESCRIPTION
This PR adds a test file which has some basic tests to verify that the whole CDC pipeline from YugabyteDB to PostgreSQL is working fine in case there are restarts of the Kafka or Kafka Connect processes.

As of now, `TestContainers` do not provide a way to restart the container instances in a pipeline. The workaround for the same is to stop the container process and start it up back again - however, this leads to an issue where the mapped ports get changed after the restart, but the original container info is still cached (see https://github.com/testcontainers/testcontainers-java/issues/761), which further introduces an overhead for the users to implement a mechanism so that the API calls refer to the newly mapped port. A function to tackle the same situation has also been introduced in this PR - `TestHelper.getContainerMappedPortFor()`.