### PR TITLE
Renamed prefixes to proper convention for cdcsdk

### DIFF
--- a/cdcsdk-server/cdcsdk-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-eventhubs/src/main/java/io/debezium/server/eventhubs/EventHubsChangeConsumer.java
@@ -46,7 +46,7 @@ public class EventHubsChangeConsumer extends BaseChangeConsumer
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventHubsChangeConsumer.class);
 
-    private static final String PROP_PREFIX = "debezium.sink.eventhubs.";
+    private static final String PROP_PREFIX = "cdcsdk.sink.eventhubs.";
     private static final String PROP_CONNECTION_STRING_NAME = PROP_PREFIX + "connectionstring";
     private static final String PROP_EVENTHUB_NAME = PROP_PREFIX + "hubname";
     private static final String PROP_PARTITION_ID = PROP_PREFIX + "partitionid";

--- a/cdcsdk-server/cdcsdk-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsTestConfigSource.java
+++ b/cdcsdk-server/cdcsdk-server-eventhubs/src/test/java/io/debezium/server/eventhubs/EventHubsTestConfigSource.java
@@ -22,20 +22,20 @@ public class EventHubsTestConfigSource extends TestConfigSource {
         Map<String, String> eventHubsTest = new HashMap<>();
 
         // event hubs sink config
-        eventHubsTest.put("debezium.sink.type", "eventhubs");
-        eventHubsTest.put("debezium.sink.eventhubs.connectionstring", getEventHubsConnectionString());
-        eventHubsTest.put("debezium.sink.eventhubs.hubname", getEventHubsName());
+        eventHubsTest.put("cdcsdk.sink.type", "eventhubs");
+        eventHubsTest.put("cdcsdk.sink.eventhubs.connectionstring", getEventHubsConnectionString());
+        eventHubsTest.put("cdcsdk.sink.eventhubs.hubname", getEventHubsName());
 
         // postgresql source config
 
-        eventHubsTest.put("debezium.source.connector.class", "io.debezium.connector.postgresql.PostgresConnector");
+        eventHubsTest.put("cdcsdk.source.connector.class", "io.debezium.connector.postgresql.PostgresConnector");
 
-        eventHubsTest.put("debezium.source." + StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+        eventHubsTest.put("cdcsdk.source." + StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
                 OFFSET_STORE_PATH.toAbsolutePath().toString());
-        eventHubsTest.put("debezium.source.offset.flush.interval.ms", "0");
-        eventHubsTest.put("debezium.source.database.server.name", "testc");
-        eventHubsTest.put("debezium.source.schema.include.list", "inventory");
-        eventHubsTest.put("debezium.source.table.include.list", "inventory.customers");
+        eventHubsTest.put("cdcsdk.source.offset.flush.interval.ms", "0");
+        eventHubsTest.put("cdcsdk.source.database.server.name", "testc");
+        eventHubsTest.put("cdcsdk.source.schema.include.list", "inventory");
+        eventHubsTest.put("cdcsdk.source.table.include.list", "inventory.customers");
 
         config = eventHubsTest;
     }

--- a/cdcsdk-server/cdcsdk-server-kinesis/src/main/java/io/debezium/server/kinesis/KinesisChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-kinesis/src/main/java/io/debezium/server/kinesis/KinesisChangeConsumer.java
@@ -47,7 +47,7 @@ public class KinesisChangeConsumer extends BaseChangeConsumer implements Debeziu
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KinesisChangeConsumer.class);
 
-    private static final String PROP_PREFIX = "debezium.sink.kinesis.";
+    private static final String PROP_PREFIX = "cdcsdk.sink.kinesis.";
     private static final String PROP_REGION_NAME = PROP_PREFIX + "region";
     private static final String PROP_ENDPOINT_NAME = PROP_PREFIX + "endpoint";
 

--- a/cdcsdk-server/cdcsdk-server-pravega/src/main/java/io/debezium/server/pravega/PravegaSink.java
+++ b/cdcsdk-server/cdcsdk-server-pravega/src/main/java/io/debezium/server/pravega/PravegaSink.java
@@ -1,8 +1,8 @@
 /*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
+* Copyright Debezium Authors.
+*
+* Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*/
 package io.debezium.server.pravega;
 
 import io.debezium.engine.ChangeEvent;

--- a/cdcsdk-server/cdcsdk-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-pubsub/src/main/java/io/debezium/server/pubsub/PubSubChangeConsumer.java
@@ -52,7 +52,7 @@ public class PubSubChangeConsumer extends BaseChangeConsumer implements Debezium
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PubSubChangeConsumer.class);
 
-    private static final String PROP_PREFIX = "debezium.sink.pubsub.";
+    private static final String PROP_PREFIX = "cdcsdk.sink.pubsub.";
     private static final String PROP_PROJECT_ID = PROP_PREFIX + "project.id";
 
     public static interface PublisherBuilder {

--- a/cdcsdk-server/cdcsdk-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
+++ b/cdcsdk-server/cdcsdk-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
@@ -44,7 +44,7 @@ public class PulsarChangeConsumer extends BaseChangeConsumer implements Debezium
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PulsarChangeConsumer.class);
 
-    private static final String PROP_PREFIX = "debezium.sink.pulsar.";
+    private static final String PROP_PREFIX = "cdcsdk.sink.pulsar.";
     private static final String PROP_CLIENT_PREFIX = PROP_PREFIX + "client.";
     private static final String PROP_PRODUCER_PREFIX = PROP_PREFIX + "producer.";
 

--- a/cdcsdk-server/cdcsdk-server-pulsar/src/test/java/io/debezium/server/pulsar/PulsarTestResourceLifecycleManager.java
+++ b/cdcsdk-server/cdcsdk-server-pulsar/src/test/java/io/debezium/server/pulsar/PulsarTestResourceLifecycleManager.java
@@ -35,7 +35,7 @@ public class PulsarTestResourceLifecycleManager implements QuarkusTestResourceLi
         container.start();
 
         Map<String, String> params = new ConcurrentHashMap<>();
-        params.put("debezium.sink.pulsar.client.serviceUrl", getPulsarServiceUrl());
+        params.put("cdcsdk.sink.pulsar.client.serviceUrl", getPulsarServiceUrl());
 
         return params;
     }


### PR DESCRIPTION
This PR has the diff to rename the prefixes for the server names from `debezium.sink.` to `cdcsdk.sink.`