### PR TITLE
mvn verify runs successfully

### DIFF
--- a/.github/workflows/sanity-workflow.yml
+++ b/.github/workflows/sanity-workflow.yml
@@ -21,4 +21,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Sanity Test that code compiles and tests pass.
-        run: mvn clean package -Dquick
+        run: mvn verify

--- a/cdcsdk-engine/pom.xml
+++ b/cdcsdk-engine/pom.xml
@@ -44,13 +44,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cdcsdk-parent/pom.xml
+++ b/cdcsdk-parent/pom.xml
@@ -304,9 +304,9 @@
                         <artifactId>maven-checkstyle-plugin</artifactId>
                         <dependencies>
                             <dependency>
-                                <groupId>io.debezium</groupId>
-                                <artifactId>debezium-checkstyle</artifactId>
-                                <version>${version.debezium}</version>
+                                <groupId>com.yugabyte</groupId>
+                                <artifactId>cdcsdk-checkstyle</artifactId>
+                                <version>${project.version}</version>
                             </dependency>
                         </dependencies>
                         <configuration>

--- a/cdcsdk-server/cdcsdk-server-core/pom.xml
+++ b/cdcsdk-server/cdcsdk-server-core/pom.xml
@@ -47,12 +47,6 @@
         <dependency>
             <groupId>com.yugabyte</groupId>
             <artifactId>cdcsdk-engine</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Testing -->

--- a/cdcsdk-server/cdcsdk-server-pravega/src/main/java/io/debezium/server/pravega/PravegaSink.java
+++ b/cdcsdk-server/cdcsdk-server-pravega/src/main/java/io/debezium/server/pravega/PravegaSink.java
@@ -1,8 +1,8 @@
 /*
-* Copyright Debezium Authors.
-*
-* Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-*/
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.server.pravega;
 
 import io.debezium.engine.ChangeEvent;

--- a/cdcsdk-server/cdcsdk-server-s3/src/main/java/com/yugabyte/cdcsdk/sink/s3/config/S3SinkConnectorConfig.java
+++ b/cdcsdk-server/cdcsdk-server-s3/src/main/java/com/yugabyte/cdcsdk/sink/s3/config/S3SinkConnectorConfig.java
@@ -921,7 +921,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     }
 
     public static void main(String[] args) {
+        // CHECKSTYLE:OFF
         System.out.println(getConfig().toEnrichedRst());
+        // CHECKSTYLE:ON
     }
 
 }

--- a/cdcsdk-server/cdcsdk-server-s3/src/test/java/com/yugabyte/cdcsdk/sink/s3/RollingOutputStreamTest.java
+++ b/cdcsdk-server/cdcsdk-server-s3/src/test/java/com/yugabyte/cdcsdk/sink/s3/RollingOutputStreamTest.java
@@ -65,8 +65,9 @@ public class RollingOutputStreamTest {
     @AfterEach
     void cleanTempDir() {
         for (File file : testDir.toFile().listFiles()) {
-            if (!file.isDirectory())
+            if (!file.isDirectory()) {
                 file.delete();
+            }
         }
     }
 

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/PostgresSinkConsumerIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/PostgresSinkConsumerIT.java
@@ -1,9 +1,8 @@
 package com.yugabyte.cdcsdk.testing;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.lang.Double;
-import java.lang.String;
 import java.sql.ResultSet;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -13,7 +12,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,7 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yugabyte.cdcsdk.testing.util.CdcsdkTestBase;
 import com.yugabyte.cdcsdk.testing.util.UtilStrings;
 
-import io.debezium.testing.testcontainers.*;
+import io.debezium.testing.testcontainers.ConnectorConfiguration;
 
 /**
  * Release test that verifies basic reading from a YugabyteDB database and

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/PubSubConsumerIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/PubSubConsumerIT.java
@@ -6,7 +6,8 @@
 
 package com.yugabyte.cdcsdk.testing;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -37,8 +38,10 @@ import com.yugabyte.cdcsdk.testing.util.UtilStrings;
  */
 
 public class PubSubConsumerIT extends CdcsdkTestBase {
-    private static String projectId = System.getenv("GCLOUD_PROJECT");// We are using project id ="yugabyte";
-    private static String subscriptionId = System.getenv("SUBSCRIPTION_ID");// We are using subscription id"dbserver1.public.test_table-sub";
+    // We are using project id ="yugabyte";
+    private static String projectId = System.getenv("GCLOUD_PROJECT");
+    // We are using subscription id"dbserver1.public.test_table-sub";
+    private static String subscriptionId = System.getenv("SUBSCRIPTION_ID");
 
     @BeforeAll
     public static void beforeClass() throws Exception {

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/S3ConsumerRelIT.java
@@ -6,7 +6,8 @@
 
 package com.yugabyte.cdcsdk.testing;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.InputStream;

--- a/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/ServerRestartTestIT.java
+++ b/cdcsdk-testing/src/test/java/com/yugabyte/cdcsdk/testing/ServerRestartTestIT.java
@@ -1,8 +1,8 @@
 package com.yugabyte.cdcsdk.testing;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import java.lang.String;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -26,7 +26,7 @@ import com.yugabyte.cdcsdk.testing.util.CdcsdkContainer;
 import com.yugabyte.cdcsdk.testing.util.CdcsdkTestBase;
 import com.yugabyte.cdcsdk.testing.util.IOT;
 
-import io.debezium.testing.testcontainers.*;
+import io.debezium.testing.testcontainers.ConnectorConfiguration;
 
 /**
  * Release test that verifies basic reading from a YugabyteDB database and

--- a/pom.xml
+++ b/pom.xml
@@ -427,3 +427,4 @@
         </profile>
     </profiles>
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,7 @@
         <version.zookeeper>3.5.9</version.zookeeper>
         <version.jackson>2.10.5</version.jackson>
         <version.jackson.databind>2.10.5.1</version.jackson.databind>
-        <version.org.slf4j>1.7.30</version.org.slf4j>
-        <version.log4j>1.2.17</version.log4j>
+        <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.netty>4.1.51.Final</version.netty>
 
         <!-- Scala version used to build Kafka -->
@@ -100,10 +99,10 @@
     </properties>
 
     <modules>
-        <module>cdcsdk-parent</module>
         <module>support/checkstyle</module>
         <module>support/ide-configs</module>
         <module>support/revapi</module>
+        <module>cdcsdk-parent</module>
         <module>cdcsdk-engine</module>
         <module>cdcsdk-server</module>
         <module>cdcsdk-testing</module>

--- a/support/checkstyle/src/main/resources/checkstyle.xml
+++ b/support/checkstyle/src/main/resources/checkstyle.xml
@@ -16,7 +16,7 @@
         <!-- Exclude any classes that keep their own copyright and header -->
         <property name="excludedClasses" value="io.debezium.util.VariableLatch"/>
         <!-- Exclude any directories that contain completely different headers -->
-        <property name="excludedFilesRegex" value="io/debezium/annotation/.*"/>
+        <property name="excludedFilesRegex" value="(io/debezium/annotation/.*)|(com/yugabyte/.*)"/>
     </module>
 
     <module name="TreeWalker">

--- a/support/checkstyle/src/main/resources/checkstyle.xml
+++ b/support/checkstyle/src/main/resources/checkstyle.xml
@@ -174,3 +174,4 @@
     </module>
 
 </module>
+


### PR DESCRIPTION
Previously `mvn integration-tests` was used to run integration tests. However that command does not error out if integration tests fail. The right command to use is `mvn verify`. To make `mvn verify`, the following changes were required:
* Restrict header checks to io.debezium classes
* Remove usage of log4j
* Remove usage of star imports