### PR TITLE
Start using the latest release for the Debezium Connector

### DIFF
--- a/cdcsdk-server/cdcsdk-server-bom/pom.xml
+++ b/cdcsdk-server/cdcsdk-server-bom/pom.xml
@@ -28,7 +28,7 @@
 
         <version.debezium>1.9.5.Final</version.debezium>
         <!-- YugabyteDB Dependencies -->
-        <version.yugabytedb>1.9.5.y.6</version.yugabytedb>
+        <version.yugabytedb>1.9.5.y.11</version.yugabytedb>
 
 
         <version.commons.logging>1.2</version.commons.logging>


### PR DESCRIPTION
This PR updates the version of Debezium Connector for YugabyteDB to be used with `cdcsdk-server`.