### PR TITLE
Revert a minor change from #7e802d7

### DIFF
--- a/cdcsdk-server/cdcsdk-server-dist/pom.xml
+++ b/cdcsdk-server/cdcsdk-server-dist/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>debezium-connector-yugabytedb</artifactId>
         </dependency>
         <dependency>
+             <groupId>com.yugabyte</groupId>
+             <artifactId>cdcsdk-server-core</artifactId>
+         </dependency>
+        <dependency>
             <groupId>com.yugabyte</groupId>
             <artifactId>cdcsdk-engine</artifactId>
         </dependency>


### PR DESCRIPTION
Accidentally removed a dependency from the dist pom.xml. This caused a fatal error where the packaged jar did not start up. Revert the change.